### PR TITLE
docs: modified CI workflow with new conditions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,6 +22,8 @@ concurrency:
 
 jobs:
   pdf:
+    if: ${{ github.event_name == 'push' ||
+            github.event_name == 'pull_request' && startsWith(github.head_ref, 'docs/') }}
     runs-on: ubuntu-latest
     container: texlive/texlive
     steps:


### PR DESCRIPTION
Only trigger pdf build when pushing to `master` or when PR is either opened or sync'ed with its source branch being `docs/*` and its target branch being `master`.